### PR TITLE
Manually Pin Ruby Version

### DIFF
--- a/tasks/ruby.yml
+++ b/tasks/ruby.yml
@@ -20,3 +20,18 @@
   become_method: sudo
   become_flags: -Hi
   when: ruby_version_changed or ruby_install_result|changed
+
+- name: set the ruby version on disk
+  copy:
+    content: "{{ ruby_version }}"
+    dest: "{{ ruby_user_home }}/{{ item }}"
+    owner: "{{ ruby_user }}"
+    group: "{{ ruby_user }}"
+    mode: "0644"
+  become: true
+  become_user: "{{ ruby_user }}"
+  become_method: sudo
+  become_flags: -Hi
+  with_items:
+    - .ruby-version
+    - .rbenv/version

--- a/tests/goss.d/files.yml
+++ b/tests/goss.d/files.yml
@@ -11,3 +11,14 @@ file:
       - /\$\(rbenv init \-\)/
   '/home/{{.Env.ruby_user}}/.rbenv':
     exists: true
+
+  # rbenv seems to get confused unless we manually kang these files
+  '/home/{{.Env.ruby_user}}/.rbenv/version':
+    exists: true
+    contains:
+      - "{{.Env.ruby_version}}"
+
+  '/home/{{.Env.ruby_user}}/.ruby-version':
+    exists: true
+    contains:
+      - "{{.Env.ruby_version}}"


### PR DESCRIPTION
Downstream `naftulikay.vagrant-ruby-dev` is affected by this bug; for some reason (most likely cwd), rbenv doesn't work downstream without pinning to these files manually.

It's not ideal, but something that works is invariably chosen over something that doesn't.